### PR TITLE
fix(server): drain-aware listener — leave SO_REUSEPORT pool while draining

### DIFF
--- a/qw/conf.py
+++ b/qw/conf.py
@@ -47,6 +47,11 @@ WORKER_HEALTH_PORT = config.getint('WORKER_HEALTH_PORT', fallback=8080)
 WORKER_HEARTBEAT_INTERVAL = config.getint('WORKER_HEARTBEAT_INTERVAL', fallback=5)
 WORKER_HEARTBEAT_TIMEOUT = config.getint('WORKER_HEARTBEAT_TIMEOUT', fallback=30)
 WORKER_DRAIN_TIMEOUT = config.getint('WORKER_DRAIN_TIMEOUT', fallback=300)
+# How often (seconds) a worker re-checks its draining status to add/remove
+# its listening socket from the SO_REUSEPORT pool (FEAT: drain-aware listener).
+WORKER_DRAIN_LISTENER_INTERVAL = config.getint(
+    'WORKER_DRAIN_LISTENER_INTERVAL', fallback=2
+)
 SUPERVISOR_CHECK_INTERVAL = config.getint('SUPERVISOR_CHECK_INTERVAL', fallback=10)
 SUPERVISOR_KILL_GRACE = config.getint('SUPERVISOR_KILL_GRACE', fallback=10)
 

--- a/qw/server.py
+++ b/qw/server.py
@@ -33,6 +33,7 @@ from .conf import (
     WORKER_HEALTH_ENABLED,
     WORKER_HEALTH_PORT,
     WORKER_HEARTBEAT_INTERVAL,
+    WORKER_DRAIN_LISTENER_INTERVAL,
 )
 from datamodel.parsers.json import json_encoder
 from .utils.versions import get_versions
@@ -96,6 +97,12 @@ class QWorker:
         )
         # FEAT-005: background heartbeat task — created in start()
         self._heartbeat_task: Optional[asyncio.Task] = None
+        # FEAT: drain-aware listener — watcher task that adds/removes this
+        # worker's listening socket from the SO_REUSEPORT pool by status.
+        self._drain_watch_task: Optional[asyncio.Task] = None
+        # Cached "host:port" of the listening socket(s); kept valid even
+        # while the listener is closed during draining (used by info/health).
+        self._serving_addrs: str = ""
         # logging:
         self.logger = logging.getLogger(
             f'QW.Server:{self._name}.{self._id}'
@@ -374,15 +381,26 @@ class QWorker:
         except Exception:  # pragma: no cover — defensive
             return False
 
-    async def start(self):
-        # Redis Service:
-        self.start_redis()
-        """Starts Queue Manager."""
-        self.queue = QueueManager(worker_name=self._name, state_tracker=self._state)
-        # Subscription Manager:
-        self.subscription_task = self._loop.create_task(
-            self.start_subscription()
-        )
+    # ------------------------------------------------------------------
+    # FEAT: drain-aware listener — keep draining workers out of the
+    # SO_REUSEPORT pool so the kernel stops routing new connections to them.
+    # ------------------------------------------------------------------
+
+    async def _open_listener(self) -> None:
+        """Create the TCP listener and join the SO_REUSEPORT pool.
+
+        Extracted from ``start()`` so the drain watcher can reopen the
+        listener after a worker recovers from ``draining``. The server
+        begins accepting connections as soon as it is created
+        (``start_serving=True`` by default), so no explicit
+        ``serve_forever()`` call is required.
+
+        Raises:
+            QWException: if the listening socket cannot be created.
+        """
+        if self._server is not None:
+            # Listener already open — nothing to do.
+            return
         try:
             if self._protocol:
                 self._server = await self._loop.create_server(
@@ -404,6 +422,11 @@ class QWorker:
             self.server_address = (
                 socket.gethostbyname(socket.gethostname()), self.port
             )
+            # Cache the serving address so info/health commands keep working
+            # even while the listener is closed during draining.
+            self._serving_addrs = ', '.join(
+                str(sock.getsockname()) for sock in self._server.sockets
+            )
             sock = self._server.sockets[0].getsockname()
             self.logger.info(
                 f'Serving {self._name}:{self._id} on {sock}, pid: {self._pid}'
@@ -412,6 +435,77 @@ class QWorker:
             raise QWException(
                 f"Error: {err}"
             ) from err
+
+    async def _close_listener(self) -> None:
+        """Close the TCP listener so this worker leaves the SO_REUSEPORT pool.
+
+        Only the acceptance of NEW connections stops — connections already
+        being served (tasks in flight) are NOT interrupted. With the
+        listener removed from the pool the kernel routes new client
+        connections to healthy sibling workers instead of this one.
+        """
+        if self._server is None:
+            return
+        server, self._server = self._server, None
+        try:
+            server.close()
+            await server.wait_closed()
+        except Exception as err:  # pragma: no cover — defensive
+            self.logger.error(
+                f"Error closing listener on {self._name}: {err}"
+            )
+
+    async def _drain_listener_watcher(self) -> None:
+        """Toggle the listening socket in/out of the SO_REUSEPORT pool.
+
+        A worker marked ``draining`` by the supervisor must stop accepting
+        NEW TCP connections; otherwise SO_REUSEPORT keeps routing client
+        connections to it and the tasks it then rejects can be lost. When
+        the worker recovers to ``healthy`` the listener is reopened so it
+        rejoins the pool. Runs until ``self._running`` is cleared by
+        ``shutdown()``.
+        """
+        while self._running:
+            try:
+                draining = self._is_draining()
+                if draining and self._server is not None:
+                    self.logger.warning(
+                        "Worker %s is draining — closing listener to leave "
+                        "the SO_REUSEPORT pool",
+                        self._name,
+                    )
+                    await self._close_listener()
+                elif not draining and self._server is None:
+                    self.logger.info(
+                        "Worker %s recovered — reopening listener to rejoin "
+                        "the SO_REUSEPORT pool",
+                        self._name,
+                    )
+                    await self._open_listener()
+            except asyncio.CancelledError:
+                break
+            except Exception:  # pragma: no cover — defensive
+                self.logger.exception(
+                    "drain listener watcher error on %s", self._name
+                )
+            try:
+                await asyncio.sleep(WORKER_DRAIN_LISTENER_INTERVAL)
+            except asyncio.CancelledError:
+                break
+
+    async def start(self):
+        # Redis Service:
+        self.start_redis()
+        """Starts Queue Manager."""
+        self.queue = QueueManager(worker_name=self._name, state_tracker=self._state)
+        # Subscription Manager:
+        self.subscription_task = self._loop.create_task(
+            self.start_subscription()
+        )
+        # FEAT: drain-aware listener — listener creation lives in
+        # _open_listener() so the drain watcher can reopen the socket after
+        # the worker recovers from "draining".
+        await self._open_listener()
         # Start HTTP health server (only on first worker to avoid port conflicts)
         if WORKER_HEALTH_ENABLED and self._id == 0:
             try:
@@ -439,10 +533,19 @@ class QWorker:
             # consumers are running. The loop keeps ticking until
             # self._running is set to False by shutdown().
             self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
-            async with self._server:
-                await self._server.serve_forever()
+            # FEAT: drain-aware listener — the watcher keeps this coroutine
+            # alive (replacing serve_forever) while toggling the listener in
+            # and out of the SO_REUSEPORT pool based on draining status. The
+            # server starts accepting connections as soon as it is created
+            # (start_serving=True), so no explicit serve_forever() is needed.
+            self._drain_watch_task = asyncio.create_task(
+                self._drain_listener_watcher()
+            )
+            await self._drain_watch_task
         except (RuntimeError, KeyboardInterrupt) as err:
             self.logger.exception(err, stack_info=True)
+        except asyncio.CancelledError:
+            pass
 
     async def shutdown(self):
         self._running = False
@@ -461,6 +564,19 @@ class QWorker:
             except Exception as hb_err:  # pragma: no cover — defensive
                 self.logger.error(f"Heartbeat task shutdown error: {hb_err}")
             self._heartbeat_task = None
+        # FEAT: drain-aware listener — cancel the watcher so it stops
+        # toggling the listener and releases the start() coroutine.
+        if self._drain_watch_task is not None:
+            self._drain_watch_task.cancel()
+            try:
+                await self._drain_watch_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as dw_err:  # pragma: no cover — defensive
+                self.logger.error(
+                    f"Drain watcher shutdown error: {dw_err}"
+                )
+            self._drain_watch_task = None
         # Stop health server first
         if self._health_server is not None:
             try:
@@ -478,8 +594,11 @@ class QWorker:
         except KeyboardInterrupt:
             pass
         try:
-            self._server.close()
-            await self._server.wait_closed()
+            # The listener may already be closed if the worker was draining.
+            if self._server is not None:
+                self._server.close()
+                await self._server.wait_closed()
+                self._server = None
         except RuntimeError as err:
             self.logger.exception(
                 err, stack_info=True
@@ -508,7 +627,7 @@ class QWorker:
         writer: asyncio.StreamWriter,
         status: dict = None
     ) -> None:
-        addrs = ', '.join(str(sock.getsockname()) for sock in self._server.sockets)
+        addrs = self._serving_addrs
         if not status:
             status = {
                 "pong": "Empty data",
@@ -521,7 +640,7 @@ class QWorker:
         await self.closing_writer(writer, result.encode('utf-8'))
 
     async def worker_health(self, writer: asyncio.StreamWriter):
-        addrs = ', '.join(str(sock.getsockname()) for sock in self._server.sockets)
+        addrs = self._serving_addrs
         status = {
             "workers": WORKER_DEFAULT_QTY,
             "queue": {
@@ -540,7 +659,7 @@ class QWorker:
 
     async def worker_check_state(self, writer: asyncio.StreamWriter):
         ## TODO: add last executed task
-        addrs = ', '.join(str(sock.getsockname()) for sock in self._server.sockets)
+        addrs = self._serving_addrs
         snap = self.queue.snapshot()
         status = {
             "versions": get_versions(),
@@ -572,7 +691,7 @@ class QWorker:
             workers = self._state.get_all_states()
         else:
             workers = {}
-        addrs = ', '.join(str(sock.getsockname()) for sock in self._server.sockets)
+        addrs = self._serving_addrs
         payload = json_encoder({
             "server": {
                 "address": self.server_address,

--- a/tests/test_drain_listener.py
+++ b/tests/test_drain_listener.py
@@ -1,0 +1,176 @@
+"""Unit tests for the drain-aware TCP listener.
+
+A worker marked ``draining`` by the supervisor must leave the
+``SO_REUSEPORT`` pool so the kernel stops routing new connections to it.
+These tests cover:
+
+- ``_open_listener()`` creates a serving socket and caches its address
+- ``_close_listener()`` closes the socket, drops ``_server`` to None, and
+  keeps the cached serving address
+- ``_close_listener()`` is a no-op when there is no listener
+- ``_drain_listener_watcher()`` closes the listener when the worker is
+  marked draining and reopens it when the worker recovers to healthy
+"""
+from __future__ import annotations
+
+import asyncio
+import multiprocessing as mp
+import socket
+import time
+
+import pytest
+
+from qw.server import QWorker
+
+
+# ----------------------------------------------------------------------
+# Fixtures / helpers
+# ----------------------------------------------------------------------
+
+
+@pytest.fixture
+def shared():
+    manager = mp.Manager()
+    d = manager.dict()
+    yield d
+    manager.shutdown()
+
+
+def _free_port() -> int:
+    """Reserve and release an ephemeral port so we can reopen on it."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _make_worker(shared_state=None, port: int = 0) -> QWorker:
+    """Build a QWorker without starting its full serve loop.
+
+    protocol is None, so _open_listener() uses asyncio.start_server() bound
+    to the running loop — self._loop is never touched by these tests.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        worker = QWorker(
+            host="127.0.0.1",
+            port=port,
+            worker_id=0,
+            name="TestWorker",
+            event_loop=loop,
+            shared_state=shared_state,
+        )
+    finally:
+        loop.close()
+    return worker
+
+
+async def _wait_for(predicate, timeout: float = 2.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        await asyncio.sleep(0.01)
+    return predicate()
+
+
+# ----------------------------------------------------------------------
+# _open_listener / _close_listener
+# ----------------------------------------------------------------------
+
+
+class TestOpenCloseListener:
+    @pytest.mark.asyncio
+    async def test_open_then_close(self):
+        worker = _make_worker(port=_free_port())
+        await worker._open_listener()
+        try:
+            assert worker._server is not None
+            assert worker._server.sockets, "expected at least one socket"
+            assert worker._serving_addrs != ""
+            cached = worker._serving_addrs
+        finally:
+            await worker._close_listener()
+
+        # Listener gone from the pool, but the cached address is retained
+        # so info/health commands keep returning a sensible value.
+        assert worker._server is None
+        assert worker._serving_addrs == cached
+
+    @pytest.mark.asyncio
+    async def test_open_is_idempotent(self):
+        worker = _make_worker(port=_free_port())
+        await worker._open_listener()
+        first = worker._server
+        try:
+            await worker._open_listener()  # second call must not replace it
+            assert worker._server is first
+        finally:
+            await worker._close_listener()
+
+    @pytest.mark.asyncio
+    async def test_close_without_listener_is_noop(self):
+        worker = _make_worker()
+        assert worker._server is None
+        await worker._close_listener()  # must not raise
+        assert worker._server is None
+
+
+# ----------------------------------------------------------------------
+# _drain_listener_watcher
+# ----------------------------------------------------------------------
+
+
+class TestDrainListenerWatcher:
+    @pytest.mark.asyncio
+    async def test_watcher_closes_on_drain_and_reopens_on_recovery(
+        self, shared, monkeypatch
+    ):
+        # Tight poll so the test runs fast.
+        monkeypatch.setattr(
+            "qw.server.WORKER_DRAIN_LISTENER_INTERVAL", 0.01
+        )
+
+        port = _free_port()
+        worker = _make_worker(shared_state=shared, port=port)
+        await worker._open_listener()
+        assert worker._server is not None
+
+        task = asyncio.create_task(worker._drain_listener_watcher())
+        try:
+            # Mark draining → watcher must drop the listener from the pool.
+            worker._state.set_status("draining", draining_since=time.time())
+            assert await _wait_for(lambda: worker._server is None), \
+                "listener should close while draining"
+
+            # Recover → watcher must reopen the listener.
+            worker._state.set_status("healthy")
+            assert await _wait_for(lambda: worker._server is not None), \
+                "listener should reopen after recovery"
+        finally:
+            worker._running = False
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            await worker._close_listener()
+
+    @pytest.mark.asyncio
+    async def test_watcher_exits_when_running_cleared(self, shared, monkeypatch):
+        monkeypatch.setattr(
+            "qw.server.WORKER_DRAIN_LISTENER_INTERVAL", 0.01
+        )
+        worker = _make_worker(shared_state=shared)
+        task = asyncio.create_task(worker._drain_listener_watcher())
+        await asyncio.sleep(0.05)
+        worker._running = False
+        # The loop checks _running at the top; cancel to avoid waiting a
+        # full sleep interval, mirroring the heartbeat-loop test style.
+        task.cancel()
+        try:
+            await asyncio.wait_for(task, timeout=1.0)
+        except asyncio.CancelledError:
+            pass
+        assert task.done()


### PR DESCRIPTION
## Problem

A worker marked `draining` by the supervisor (FEAT-005) **keeps its listening socket open**. Since all worker processes share the port via `SO_REUSEPORT`, the kernel's balancer keeps routing **new** connections to the draining worker. That worker then rejects every queued task with a `QWException("... is draining, retry on another worker")` (`server.py`, `queues/manager.py`), but the client does **not** re-route on that rejection — so the task can be lost.

This is especially nasty under **CPU saturation**: a saturated event loop starves the asyncio heartbeat loop (`_heartbeat_loop`), the heartbeat goes stale, and the supervisor marks the worker `draining` — exactly the moment the worker should stop receiving traffic, yet it keeps getting connections and dropping tasks.

The existing code comments even state the intended behavior (*"SO_REUSEPORT will re-route the next TCP connection to a healthy sibling"*), but that never happens because the draining process never leaves the pool.

## Fix

Make the listener **drain-aware**. A background watcher (`_drain_listener_watcher`) closes the listening socket when the worker becomes `draining` — removing it from the `SO_REUSEPORT` pool so the kernel only routes to healthy siblings — and reopens it when the worker recovers to `healthy`. In-flight tasks are never interrupted; only the acceptance of *new* connections stops.

### Changes
- Extract listener creation into `_open_listener()`; add `_close_listener()`.
- `start()` relies on the watcher to stay alive instead of `serve_forever()` (the server accepts connections as soon as it is created, so `serve_forever()` was not required).
- Cache the serving address in `_serving_addrs` so the `info`/`health` TCP commands keep working while the listener is closed.
- Cancel the watcher and guard `self._server is None` in `shutdown()`.
- New config `WORKER_DRAIN_LISTENER_INTERVAL` (default `2s`) controls the poll cadence.

### Tests
- `tests/test_drain_listener.py`: open/close/idempotency of the listener, no-op close, and the watcher closing on drain / reopening on recovery.
- Full existing suite stays green (`372 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)